### PR TITLE
선언적 트랜잭션을 이용하여 엔티티 수정 코드 변경

### DIFF
--- a/src/main/java/com/magnet/magnet/domain/club/api/ClubController.java
+++ b/src/main/java/com/magnet/magnet/domain/club/api/ClubController.java
@@ -70,8 +70,8 @@ public class ClubController {
                     @ApiResponse(responseCode = "403", description = "인증 오류 (토큰)"),
                     @ApiResponse(responseCode = "500", description = "관리자 문의")
             })
-    public ResponseEntity<ResponseClub> getClub(@PathVariable("clubId") Long id) {
-        return ResponseEntity.ok(clubService.getClub(id));
+    public ResponseEntity<ResponseClub> getClub(@PathVariable("clubId") Long id, Principal principal) {
+        return ResponseEntity.ok(clubService.getClub(id, principal.getName()));
     }
 
     @GetMapping("/myClub")

--- a/src/main/java/com/magnet/magnet/domain/club/app/ClubService.java
+++ b/src/main/java/com/magnet/magnet/domain/club/app/ClubService.java
@@ -14,8 +14,8 @@ public interface ClubService {
 
     ResponseClub deleteClub(Long id, String email);
 
-    ResponseClub getClub(Long id);
+    ResponseClub getClub(Long id, String email);
 
-    List<ResponseClub> getMyClubList( String email);
+    List<ResponseClub> getMyClubList(String email);
 
 }

--- a/src/main/java/com/magnet/magnet/domain/club/app/impl/ClubManageServiceImpl.java
+++ b/src/main/java/com/magnet/magnet/domain/club/app/impl/ClubManageServiceImpl.java
@@ -12,6 +12,7 @@ import com.magnet.magnet.global.exception.CustomException;
 import com.magnet.magnet.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +25,7 @@ public class ClubManageServiceImpl implements ClubManageService {
     private final ClubUserRepo clubUserRepo;
 
     @Override
+    @Transactional
     public void setUserAsAdmin(RequestManagement dto, String email) {
         Club findClub = getClubByIdAndDeletedFalse(dto.getClubId());
 
@@ -39,10 +41,10 @@ public class ClubManageServiceImpl implements ClubManageService {
         ClubUser findClubUser = getClubUserByClubAndUserAndDeletedFalse(findClub, findUser);
 
         findClubUser.updateRoleToAdmin();
-        clubUserRepo.save(findClubUser);
     }
 
     @Override
+    @Transactional
     public void setUserAsUser(RequestManagement dto, String email) {
         Club findClub = getClubByIdAndDeletedFalse(dto.getClubId());
 
@@ -55,10 +57,10 @@ public class ClubManageServiceImpl implements ClubManageService {
         ClubUser findClubUser = getClubUserByClubAndUserAndDeletedFalse(findClub, findUser);
 
         findClubUser.updateRoleToUser();
-        clubUserRepo.save(findClubUser);
     }
 
     @Override
+    @Transactional
     public void deleteUser(RequestManagement dto, String email) {
         Club findClub = getClubByIdAndDeletedFalse(dto.getClubId());
 
@@ -71,7 +73,6 @@ public class ClubManageServiceImpl implements ClubManageService {
         ClubUser findClubUser = getClubUserByClubAndUserAndDeletedFalse(findClub, findUser);
 
         findClubUser.deleteClubUser();
-        clubUserRepo.save(findClubUser);
     }
 
     private User getUserByEmail(String email) {

--- a/src/main/java/com/magnet/magnet/domain/club/domain/Club.java
+++ b/src/main/java/com/magnet/magnet/domain/club/domain/Club.java
@@ -38,8 +38,11 @@ public class Club extends BaseTime {
     @Builder.Default
     private boolean deleted = false;
 
-    public void updateClub(String newTitle, String newDescription) {
+    public void updateClubTitle(String newTitle) {
         this.title = newTitle;
+    }
+
+    public void updateClubDescription(String newDescription) {
         this.description = newDescription;
     }
 

--- a/src/main/java/com/magnet/magnet/domain/invitation/app/impl/JoinRequestServiceImpl.java
+++ b/src/main/java/com/magnet/magnet/domain/invitation/app/impl/JoinRequestServiceImpl.java
@@ -86,8 +86,6 @@ public class JoinRequestServiceImpl implements JoinRequestService {
                 .user(findRequest.getUser())
                 .role(ClubUser.Role.USER)
                 .build());
-
-        joinRequestRepo.save(findRequest);
     }
 
     @Override
@@ -100,8 +98,6 @@ public class JoinRequestServiceImpl implements JoinRequestService {
         validateAdminRole(request.getClub(), currentUser);
 
         request.rejectRequest();
-
-        joinRequestRepo.save(request);
     }
 
     private User getUserByEmail(String email) {

--- a/src/main/java/com/magnet/magnet/domain/post/category/app/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/magnet/magnet/domain/post/category/app/impl/CategoryServiceImpl.java
@@ -54,9 +54,8 @@ public class CategoryServiceImpl implements CategoryService {
 
         validateAdminRole(findCategory.getClub(), currentUser);
 
-        findCategory.updateTitle(dto.getCategoryTitle());
-        findCategory.updateDescription(dto.getCategoryDescription());
-        categoryRepo.save(findCategory);
+        findCategory.updateCategoryTitle(dto.getCategoryTitle());
+        findCategory.updateCategoryDescription(dto.getCategoryDescription());
     }
 
 
@@ -72,7 +71,6 @@ public class CategoryServiceImpl implements CategoryService {
         validateAdminRole(findCategory.getClub(), currentUser);
 
         findCategory.deleteCategory();
-        categoryRepo.save(findCategory);
     }
 
     @Override

--- a/src/main/java/com/magnet/magnet/domain/post/category/app/impl/SubscribeServiceImpl.java
+++ b/src/main/java/com/magnet/magnet/domain/post/category/app/impl/SubscribeServiceImpl.java
@@ -48,7 +48,6 @@ public class SubscribeServiceImpl implements SubscribeService {
         Subscribe findSubscribe = getSubscribeByIdAndStatus(categoryId, Subscribe.Status.SUBSCRIBE);
 
         findSubscribe.unSubscribe();
-        subscribeRepo.save(findSubscribe);
     }
 
     @Override

--- a/src/main/java/com/magnet/magnet/domain/post/category/domain/Category.java
+++ b/src/main/java/com/magnet/magnet/domain/post/category/domain/Category.java
@@ -30,11 +30,11 @@ public class Category extends BaseTime {
     @Builder.Default
     private boolean deleted = false;
 
-    public void updateTitle(String newTitle) {
+    public void updateCategoryTitle(String newTitle) {
         this.title = newTitle;
     }
 
-    public void updateDescription(String newDescription) {
+    public void updateCategoryDescription(String newDescription) {
         this.description = newDescription;
     }
 

--- a/src/main/java/com/magnet/magnet/domain/post/content/app/impl/PostServiceImpl.java
+++ b/src/main/java/com/magnet/magnet/domain/post/content/app/impl/PostServiceImpl.java
@@ -76,21 +76,19 @@ public class PostServiceImpl implements PostService {
 
         Post findPost = getPostByIdAndDeletedFalse(dto.getPostId());
 
-        findPost.updateTitle(dto.getTitle());
-        findPost.updateContent(dto.getContent());
-        findPost.updateCategory(getCategoryByTitleAndClubAndDeletedFalse(dto.getCategoryTitle(), findClub));
-
-        Post updatePost = postRepo.save(findPost);
+        findPost.updatePostTitle(dto.getTitle());
+        findPost.updatePostContent(dto.getContent());
+        findPost.updatePostCategory(getCategoryByTitleAndClubAndDeletedFalse(dto.getCategoryTitle(), findClub));
 
         return ResponsePost.builder()
-                .id(updatePost.getId())
-                .title(updatePost.getTitle())
-                .content(updatePost.getContent())
-                .writer(updatePost.getWriter().getNickname())
-                .categoryTitle(updatePost.getCategory().getTitle())
-                .location(updatePost.getLocation())
-                .createdDate(updatePost.getCreatedDate())
-                .modifiedDate(updatePost.getModifiedDate())
+                .id(findPost.getId())
+                .title(findPost.getTitle())
+                .content(findPost.getContent())
+                .writer(findPost.getWriter().getNickname())
+                .categoryTitle(findPost.getCategory().getTitle())
+                .location(findPost.getLocation())
+                .createdDate(findPost.getCreatedDate())
+                .modifiedDate(findPost.getModifiedDate())
                 .build();
     }
 
@@ -106,7 +104,6 @@ public class PostServiceImpl implements PostService {
         Post findPost = getPostByIdAndDeletedFalse(postId);
 
         findPost.deletePost();
-        postRepo.save(findPost);
 
         return ResponsePost.builder()
                 .id(findPost.getId())

--- a/src/main/java/com/magnet/magnet/domain/post/content/domain/Post.java
+++ b/src/main/java/com/magnet/magnet/domain/post/content/domain/Post.java
@@ -42,15 +42,15 @@ public class Post extends BaseTime {
     @Builder.Default
     private boolean deleted = false;
 
-    public void updateTitle(String newTitle) {
+    public void updatePostTitle(String newTitle) {
         this.title = newTitle;
     }
 
-    public void updateContent(String newContent) {
+    public void updatePostContent(String newContent) {
         this.content = newContent;
     }
 
-    public void updateCategory(Category newCategory) {
+    public void updatePostCategory(Category newCategory) {
         this.category = newCategory;
     }
 


### PR DESCRIPTION
- @ Transactional 사용
- 기존 수정 과정에 사용하던 save() 메소드 제거
- 엔티티 수정 메소드 세분화
예시)  updateClub() -> updateClubTitle(), updateClubDescription()